### PR TITLE
t2 micro was causing error when deploying

### DIFF
--- a/dc/dc.tf
+++ b/dc/dc.tf
@@ -14,7 +14,7 @@
 
 # Create a Windows Server instance to be configured as a domain controller
 resource "aws_instance" "dc" {
-  instance_type = "t2.medium"
+  instance_type = "t3.medium"
   ami           = var.ami
 
   user_data_replace_on_change = true

--- a/linux-target/linux-target.tf
+++ b/linux-target/linux-target.tf
@@ -15,7 +15,7 @@
 # Create an EC2 instance configured as an SSH target
 resource "aws_instance" "ssh-target" {
   ami                         = var.ami
-  instance_type               = "t2.micro"
+  instance_type               = "t3.micro"
   subnet_id                   = var.subnet_id
   user_data_replace_on_change = true
   vpc_security_group_ids      = [var.sg]

--- a/main/gateway.tf
+++ b/main/gateway.tf
@@ -161,7 +161,7 @@ resource "aws_key_pair" "gateway" {
 # Launch the EC2 instance that will run the StrongDM gateway
 resource "aws_instance" "gateway" {
   ami                         = data.aws_ami.ubuntu.id
-  instance_type               = "t2.micro"
+  instance_type               = "t3.micro"
   subnet_id                   = coalesce(var.gateway_subnet, one(module.network[*].gateway_subnet))
   user_data_replace_on_change = true
   iam_instance_profile        = aws_iam_instance_profile.gw_instance_profile.name

--- a/main/relay.tf
+++ b/main/relay.tf
@@ -34,7 +34,7 @@ resource "sdm_node" "relay" {
 # Launch the EC2 instance that will run the StrongDM relay
 resource "aws_instance" "relay" {
   ami                         = data.aws_ami.ubuntu.id      # Ubuntu AMI defined in amis.tf
-  instance_type               = "t2.micro"                  # Small instance suitable for relay functions
+  instance_type               = "t3.micro"                  # Small instance suitable for relay functions
   user_data_replace_on_change = true                        # Ensure user data changes trigger instance replacement
   key_name                    = aws_key_pair.relay.key_name # Key pair for SSH access
 

--- a/windowstarget/windowstarget.tf
+++ b/windowstarget/windowstarget.tf
@@ -15,7 +15,7 @@
 
 # Create a Windows Server instance configured to join a domain and serve as an RDP target
 resource "aws_instance" "windowstarget" {
-  instance_type = "t2.medium" # Medium instance with sufficient resources for Windows Server
+  instance_type = "t3.medium" # Medium instance with sufficient resources for Windows Server
   ami           = var.ami     # Windows Server AMI ID passed from variables
 
   user_data_replace_on_change = true # Ensure user data changes trigger instance replacement


### PR DESCRIPTION
t2 micro was causing error when deploying. Seems to be no longer available, at least in AWS Europe.