### PR TITLE
Security group redundant creation

### DIFF
--- a/dc/dc.tf
+++ b/dc/dc.tf
@@ -14,7 +14,7 @@
 
 # Create a Windows Server instance to be configured as a domain controller
 resource "aws_instance" "dc" {
-  instance_type = "t2.medium"
+  instance_type = "t3.medium"
   ami           = var.ami
 
   user_data_replace_on_change = true

--- a/linux-target/linux-target.tf
+++ b/linux-target/linux-target.tf
@@ -15,7 +15,7 @@
 # Create an EC2 instance configured as an SSH target
 resource "aws_instance" "ssh-target" {
   ami                         = var.ami
-  instance_type               = "t2.micro"
+  instance_type               = "t3.micro"
   subnet_id                   = var.subnet_id
   user_data_replace_on_change = true
   vpc_security_group_ids      = [var.sg]

--- a/main/docdb-target.tf
+++ b/main/docdb-target.tf
@@ -39,7 +39,7 @@ resource "sdm_resource" "docdb-target" {
     username      = one(module.docdb-target[*].docdb_username) # Admin username
     password      = one(module.docdb-target[*].docdb_password) # Admin password
     auth_database = "admin"                                    # Default authentication database
-    replica_set   = "rs0"                                      # Default replica set name
+# 	replica_set   = "rs0"                                      # Default replica set name
     tags          = merge(one(module.docdb-target[*].thistagset), {
       sdm__cloud_id = one(module.docdb-target[*].cluster_id)
     })

--- a/main/gateway.tf
+++ b/main/gateway.tf
@@ -161,7 +161,7 @@ resource "aws_key_pair" "gateway" {
 # Launch the EC2 instance that will run the StrongDM gateway
 resource "aws_instance" "gateway" {
   ami                         = data.aws_ami.ubuntu.id
-  instance_type               = "t2.micro"
+  instance_type               = "t3.micro"
   subnet_id                   = coalesce(var.gateway_subnet, one(module.network[*].gateway_subnet))
   user_data_replace_on_change = true
   iam_instance_profile        = aws_iam_instance_profile.gw_instance_profile.name

--- a/main/relay.tf
+++ b/main/relay.tf
@@ -34,7 +34,7 @@ resource "sdm_node" "relay" {
 # Launch the EC2 instance that will run the StrongDM relay
 resource "aws_instance" "relay" {
   ami                         = data.aws_ami.ubuntu.id      # Ubuntu AMI defined in amis.tf
-  instance_type               = "t2.micro"                  # Small instance suitable for relay functions
+  instance_type               = "t3.micro"                  # Small instance suitable for relay functions
   user_data_replace_on_change = true                        # Ensure user data changes trigger instance replacement
   key_name                    = aws_key_pair.relay.key_name # Key pair for SSH access
 

--- a/network/network.tf
+++ b/network/network.tf
@@ -385,7 +385,7 @@ resource "aws_vpc_security_group_ingress_rule" "allow_netbios_tcp" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "allow_ssl_tcp" {
-  count             = var.create_windows_target || var.create_domain_controller ? 1 : 0
+  count = (var.create_windows_target || var.create_domain_controller) && !var.create_eks ? 1 : 0
   security_group_id = aws_security_group.relay.id
   cidr_ipv4         = aws_vpc.main.cidr_block
   from_port         = 443

--- a/windowstarget/windowstarget.tf
+++ b/windowstarget/windowstarget.tf
@@ -15,7 +15,7 @@
 
 # Create a Windows Server instance configured to join a domain and serve as an RDP target
 resource "aws_instance" "windowstarget" {
-  instance_type = "t2.medium" # Medium instance with sufficient resources for Windows Server
+  instance_type = "t3.medium" # Medium instance with sufficient resources for Windows Server
   ami           = var.ami     # Windows Server AMI ID passed from variables
 
   user_data_replace_on_change = true # Ensure user data changes trigger instance replacement


### PR DESCRIPTION
When DC resource is enabled, terraform tried to create security group twice and failed on second attempt.