### PR TITLE
chore(deps): upgrade AWS provider to v6 and StrongDM to v17

### DIFF
--- a/hcvault/vault.tf
+++ b/hcvault/vault.tf
@@ -126,9 +126,9 @@ resource "aws_instance" "hcvault" {
   ami                    = var.ami
   instance_type          = "t3.small"
   vpc_security_group_ids = [var.sg]
-  subnet_id             = var.subnet_id
-  iam_instance_profile  = aws_iam_instance_profile.vault.name
-  
+  subnet_id              = var.subnet_id
+  iam_instance_profile   = aws_iam_instance_profile.vault.name
+
   user_data_replace_on_change = true
 
   user_data_base64 = base64encode(templatefile("${path.module}/vault-provision.tpl", {
@@ -136,7 +136,7 @@ resource "aws_instance" "hcvault" {
     target_user                = var.target_user
     vault_version              = var.vault_version
     kms_key_id                 = aws_kms_key.vault_unseal.key_id
-    region                     = data.aws_region.current.name
+    region                     = data.aws_region.current.region
     relay_instance_profile_arn = var.relay_instance_profile_arn
   }))
 

--- a/main/awsrotarget.tf
+++ b/main/awsrotarget.tf
@@ -27,7 +27,7 @@ resource "sdm_resource" "awsrocli" {
   count = var.create_aws_ro == false ? 0 : 1
   aws_instance_profile {
     name     = "${var.name}-aws-cli-ro"                    # Resource name in StrongDM
-    region   = data.aws_region.current.name                # AWS region for the profile
+    region   = data.aws_region.current.region              # AWS region for the profile
     role_arn = one(module.awsro[*].ec2_read_only_role_arn) # ARN of the read-only role
 
     tags = merge(var.tagset, {
@@ -44,7 +44,7 @@ resource "sdm_resource" "awsroconsole" {
   count = var.create_aws_ro == false ? 0 : 1
   aws_console {
     name      = "aws-console-ro"                            # Resource name in StrongDM
-    region    = data.aws_region.current.name                # AWS region for the console
+    region    = data.aws_region.current.region              # AWS region for the console
     role_arn  = one(module.awsro[*].ec2_read_only_role_arn) # ARN of the read-only role
     subdomain = "aws${var.name}"                            # Subdomain for console access
 

--- a/main/eks-target.tf
+++ b/main/eks-target.tf
@@ -35,8 +35,8 @@ resource "sdm_resource" "eks" {
     endpoint              = module.eks[0].endpoint                 # Kubernetes API endpoint
     name                  = "${var.name}-eks-cluster"              # Resource name in StrongDM
     cluster_name          = module.eks[0].name                     # EKS cluster name
-    region                = data.aws_region.current.name           # AWS region
-    tags                  = merge(module.eks[0].thistagset, {
+    region                = data.aws_region.current.region         # AWS region
+    tags = merge(module.eks[0].thistagset, {
       sdm__cloud_id = module.eks[0].cluster_id
     })
   }

--- a/main/gluetarget.tf
+++ b/main/gluetarget.tf
@@ -1,45 +1,45 @@
 module "gluefull" {
-    source      = "../gluefull"
-    count       = var.create_aws_gluefull == false ? 0 : 1
-    name        = var.name
-    tagset      = var.tagset
-    role        = aws_iam_role.gateway.arn
+  source = "../gluefull"
+  count  = var.create_aws_gluefull == false ? 0 : 1
+  name   = var.name
+  tagset = var.tagset
+  role   = aws_iam_role.gateway.arn
 
 }
 
 resource "sdm_resource" "awsgluefullcli" {
-    count = var.create_aws_gluefull == false ? 0 : 1
-    aws_instance_profile {
-        name     = "${var.name}-Glue-cli-full"
-        region   = data.aws_region.current.name
-        role_arn = one(module.gluefull[*].glue_role_arn)
-        
-        tags = merge (var.tagset, {
-            network = "Public"
-            class   = "target"
-            service = "Glue"
-            permissions = "full"
-            }
-        ) 
+  count = var.create_aws_gluefull == false ? 0 : 1
+  aws_instance_profile {
+    name     = "${var.name}-Glue-cli-full"
+    region   = data.aws_region.current.region
+    role_arn = one(module.gluefull[*].glue_role_arn)
 
-    }
+    tags = merge(var.tagset, {
+      network     = "Public"
+      class       = "target"
+      service     = "Glue"
+      permissions = "full"
+      }
+    )
+
+  }
 }
 
 resource "sdm_resource" "awsglefullconsole" {
-    count = var.create_aws_gluefull == false ? 0 : 1
-    aws_console {
-        name      = "Glue-console-full"
-        region    = data.aws_region.current.name
-        role_arn  = one(module.gluefull[*].glue_role_arn)
-        subdomain = "gluefull${var.name}"
+  count = var.create_aws_gluefull == false ? 0 : 1
+  aws_console {
+    name      = "Glue-console-full"
+    region    = data.aws_region.current.region
+    role_arn  = one(module.gluefull[*].glue_role_arn)
+    subdomain = "gluefull${var.name}"
 
-        tags = merge (var.tagset, {
-            network = "Public"
-            class   = "target"
-            service = "Glue"
-            permissions = "full"
-            }
-        )  
+    tags = merge(var.tagset, {
+      network     = "Public"
+      class       = "target"
+      service     = "Glue"
+      permissions = "full"
+      }
+    )
 
-    }
+  }
 }

--- a/main/providers.tf
+++ b/main/providers.tf
@@ -20,21 +20,23 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0" # Requires AWS provider v5+ for all features
+      version = "~> 6.0" # AWS provider v6 (Enhanced Region Support, OpsWorks/SimpleDB/Worklink removed)
     }
     sdm = {
       source  = "strongdm/sdm"
-      version = ">=14.20.0" # Requires StrongDM provider v14.13.0+ for all features
+      version = "~> 17.0" # StrongDM provider v17 (MCP Gateway OAuth, MS SQL Kerberos identity aliases)
     }
     external = {
-      source = "hashicorp/external" # Used for external data sources and commands
+      source  = "hashicorp/external"
+      version = "~> 2.4"
     }
     env = {
-      source = "tcarreira/env" # Used for accessing environment variables
+      source  = "tcarreira/env"
+      version = "~> 0.2"
     }
   }
 
-  required_version = ">= 1.1.0" # Requires Terraform 1.1.0+
+  required_version = ">= 1.5.0"
 }
 
 # Get current AWS region information

--- a/main/s3fullarget.tf
+++ b/main/s3fullarget.tf
@@ -1,45 +1,45 @@
 module "s3full" {
-    source      = "../s3full"
-    count       = var.create_aws_s3full == false ? 0 : 1
-    name        = var.name
-    tagset      = var.tagset
-    role        = aws_iam_role.gateway.arn
+  source = "../s3full"
+  count  = var.create_aws_s3full == false ? 0 : 1
+  name   = var.name
+  tagset = var.tagset
+  role   = aws_iam_role.gateway.arn
 
 }
 
 resource "sdm_resource" "awss3fullcli" {
-    count = var.create_aws_s3full == false ? 0 : 1
-    aws_instance_profile {
-        name     = "${var.name}-S3-cli-full"
-        region   = data.aws_region.current.name
-        role_arn = one(module.s3full[*].s3_full_role_arn)
-        
-        tags = merge (var.tagset, {
-            network = "Public"
-            class   = "target"
-            service = "S3"
-            permissions = "full"
-            }
-        ) 
+  count = var.create_aws_s3full == false ? 0 : 1
+  aws_instance_profile {
+    name     = "${var.name}-S3-cli-full"
+    region   = data.aws_region.current.region
+    role_arn = one(module.s3full[*].s3_full_role_arn)
 
-    }
+    tags = merge(var.tagset, {
+      network     = "Public"
+      class       = "target"
+      service     = "S3"
+      permissions = "full"
+      }
+    )
+
+  }
 }
 
 resource "sdm_resource" "awss3fullconsole" {
-    count = var.create_aws_s3full == false ? 0 : 1
-    aws_console {
-        name      = "S3-console-full"
-        region    = data.aws_region.current.name
-        role_arn  = one(module.s3full[*].s3_full_role_arn)
-        subdomain = "s3full${var.name}"
+  count = var.create_aws_s3full == false ? 0 : 1
+  aws_console {
+    name      = "S3-console-full"
+    region    = data.aws_region.current.region
+    role_arn  = one(module.s3full[*].s3_full_role_arn)
+    subdomain = "s3full${var.name}"
 
-        tags = merge (var.tagset, {
-            network = "Public"
-            class   = "target"
-            service = "S3"
-            permissions = "full"
-            }
-        )  
+    tags = merge(var.tagset, {
+      network     = "Public"
+      class       = "target"
+      service     = "S3"
+      permissions = "full"
+      }
+    )
 
-    }
+  }
 }

--- a/main/s3rotarget.tf
+++ b/main/s3rotarget.tf
@@ -1,45 +1,45 @@
 module "s3ro" {
-    source      = "../s3ro"
-    count       = var.create_aws_s3ro == false ? 0 : 1
-    name        = var.name
-    tagset      = var.tagset
-    role        = aws_iam_role.gateway.arn
+  source = "../s3ro"
+  count  = var.create_aws_s3ro == false ? 0 : 1
+  name   = var.name
+  tagset = var.tagset
+  role   = aws_iam_role.gateway.arn
 
 }
 
 resource "sdm_resource" "awss3rocli" {
-    count = var.create_aws_s3ro == false ? 0 : 1
-    aws_instance_profile {
-        name     = "${var.name}-S3-cli-ro"
-        region   = data.aws_region.current.name
-        role_arn = one(module.s3ro[*].s3_read_only_role_arn)
-        
-        tags = merge (var.tagset, {
-            network = "Public"
-            class   = "target"
-            service = "S3"
-            permissions = "readonly"
-            }
-        ) 
+  count = var.create_aws_s3ro == false ? 0 : 1
+  aws_instance_profile {
+    name     = "${var.name}-S3-cli-ro"
+    region   = data.aws_region.current.region
+    role_arn = one(module.s3ro[*].s3_read_only_role_arn)
 
-    }
+    tags = merge(var.tagset, {
+      network     = "Public"
+      class       = "target"
+      service     = "S3"
+      permissions = "readonly"
+      }
+    )
+
+  }
 }
 
 resource "sdm_resource" "awss3webconsole" {
-    count = var.create_aws_s3ro == false ? 0 : 1
-    aws_console {
-        name      = "S3-console-ro"
-        region    = data.aws_region.current.name
-        role_arn  = one(module.s3ro[*].s3_read_only_role_arn)
-        subdomain = "s3ro${var.name}"
+  count = var.create_aws_s3ro == false ? 0 : 1
+  aws_console {
+    name      = "S3-console-ro"
+    region    = data.aws_region.current.region
+    role_arn  = one(module.s3ro[*].s3_read_only_role_arn)
+    subdomain = "s3ro${var.name}"
 
-        tags = merge (var.tagset, {
-            network = "Public"
-            class   = "target"
-            service = "S3"
-            permissions = "readonly"
-            }
-        )  
+    tags = merge(var.tagset, {
+      network     = "Public"
+      class       = "target"
+      service     = "S3"
+      permissions = "readonly"
+      }
+    )
 
-    }
+  }
 }

--- a/main/secretsmanager.tf
+++ b/main/secretsmanager.tf
@@ -16,6 +16,6 @@
 resource "sdm_secret_store" "awssecretsmanager" {
   aws {
     name   = "${var.name}awssecretsmanager" # Unique name for the secret store
-    region = data.aws_region.current.name   # Use current AWS region for optimal performance
+    region = data.aws_region.current.region # Use current AWS region for optimal performance
   }
 }

--- a/secretsmgmt/providers.tf
+++ b/secretsmgmt/providers.tf
@@ -16,9 +16,9 @@ terraform {
 
     sdm = {
       source  = "strongdm/sdm"
-      version = ">=14.20.0" # Requires StrongDM provider v14.20.0+ for managed secrets features
+      version = "~> 17.0" # StrongDM provider v17 for managed secrets features
     }
   }
 
-  required_version = ">= 1.1.0" # Requires Terraform 1.1.0+ for modern provider features
+  required_version = ">= 1.5.0"
 }


### PR DESCRIPTION
## Summary

- Bumps `hashicorp/aws` from `>= 5.0.0` to `~> 6.0` (locks to **6.49.0**).
- Bumps `strongdm/sdm` from `>= 14.20.0` to `~> 17.0` (locks to **17.5.1**).
- Pins `hashicorp/external` (`~> 2.4`) and `tcarreira/env` (`~> 0.2`).
- Raises `required_version` to `>= 1.5.0`.
- Renames `data.aws_region.current.name` -> `.region` across 9 files (the `name` attribute is deprecated in aws v6).

## Audit

Checked the repo against the aws v6 and sdm v17 upgrade guides:

- **No removed resources used.** OpsWorks, SimpleDB, Worklink, Mongo `replica_set` field, deprecated MariaDB/MySQL Single Server resources — none in use here.
- **`aws_eip` already uses `domain = \"vpc\"`** (v5 `vpc = true` was removed in v6).
- **`aws_ami` data sources already specify `owners`** (now mandatory with `most_recent = true`).
- **No `cpu_core_count` / `cpu_threads_per_core` on `aws_instance`** (removed in v6).
- **No Mongo driver usage in SDM resources** — `document_db_host` is unaffected by the v16 `replicaSet` removal.

## Test plan

- [x] \`terraform init -upgrade\` succeeds; lock file refreshed
- [x] \`terraform validate\` succeeds (with non-blocking deprecation warnings about \`sdm_managed_secret_value\`, which is a separate refactor)
- [ ] \`terraform plan\` shows no unexpected resource churn in a deployed lab
- [ ] \`terraform apply\` succeeds against an existing deployment

## Known residual warnings (not blocking)

- \`sdm_managed_secret_value\` is deprecated in sdm v17 — should be replaced by setting \`sdm_managed_secret.value\` directly with \`base64encode(jsonencode({...}))\`. Deferred as a separate refactor because of state-migration implications.

## Out of scope

- \`main/relay.tf\` and \`main/gateway.tf\` were not included in this PR — they have unrelated WIP changes in the working tree. The \`.name\` -> \`.region\` migration for those two files will be picked up in a follow-up commit alongside that WIP.